### PR TITLE
Fix skip method updateProductAttributesByProductFamily

### DIFF
--- a/app/Listeners/ProductEntity.php
+++ b/app/Listeners/ProductEntity.php
@@ -73,7 +73,10 @@ class ProductEntity extends AbstractEntityListener
         // get options
         $options = $event->getArgument('options');
 
-        if (empty($options['skipProductFamilyHook']) && !empty($entity->get('productFamily')) && empty($entity->isDuplicate)) {
+        $skipUpdate = empty($entity->skipUpdateProductAttributesByProductFamily)
+                        && empty($options['skipProductFamilyHook']);
+
+        if ($skipUpdate && !empty($entity->get('productFamily')) && empty($entity->isDuplicate)) {
             $this->updateProductAttributesByProductFamily($entity);
         }
     }


### PR DESCRIPTION
Fix the ability to skip method Pim\Listeners\ProductEntity::updateProductAttributesByProductFamily()